### PR TITLE
Response cookie handling

### DIFF
--- a/src/Psr15MiddlewareAdapter.php
+++ b/src/Psr15MiddlewareAdapter.php
@@ -137,6 +137,10 @@ class Psr15MiddlewareAdapter
         $response->setStatusCode($foundationResponse->getStatusCode());
         $response->setCharset($foundationResponse->getCharset() ? $foundationResponse->getCharset() : '');
 
+        foreach($foundationResponse->headers->getCookies() as $cookie) {
+            $response = $response->withCookie($cookie);
+        }
+
         return $response;
     }
 }


### PR DESCRIPTION
Symfony removes the `set-cookie` headers and saves the cookies in an extra field, so the `headers` foreach loop will not transfer them to the laravel response.

This change extends the transfer process and will add the cookies from the symfony `\Symfony\Component\HttpFoundation\Response` instance to the `\Illuminate\Http\Response` instance.

Let me know if this is correct or I simply misunderstood something. Thanks!