### PR TITLE
Generic cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Laravel PSR-15 Middleware Bridge
 =====
 
 [![Latest Version](https://img.shields.io/github/release/softonic/laravel-psr15-bridge.svg?style=flat-square)](https://github.com/softonic/laravel-psr15-bridge/releases)
-[![Software License](https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square)](LICENSE.md)
+[![Software License](https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square)](LICENSE)
 [![Build Status](https://img.shields.io/travis/softonic/laravel-psr15-bridge/master.svg?style=flat-square)](https://travis-ci.org/softonic/laravel-psr15-bridge)
 [![Coverage Status](https://img.shields.io/scrutinizer/coverage/g/softonic/laravel-psr15-bridge.svg?style=flat-square)](https://scrutinizer-ci.com/g/softonic/laravel-psr15-bridge/code-structure)
 [![Quality Score](https://img.shields.io/scrutinizer/g/softonic/laravel-psr15-bridge.svg?style=flat-square)](https://scrutinizer-ci.com/g/softonic/laravel-psr15-bridge)
@@ -47,7 +47,7 @@ public function register()
         $validator = new \HKarlstrom\Middleware\OpenApiValidation('schema.json');
     
         return Psr15MiddlewareAdapter::adapt($validator);
-    }
+    });
 }
 ```
 

--- a/src/NextHandlerAdapter.php
+++ b/src/NextHandlerAdapter.php
@@ -51,6 +51,8 @@ class NextHandlerAdapter implements RequestHandlerInterface
      * and wait for a response that must be adapter to PSR-7 response to allow the
      * PSR-15 middleware process it.
      *
+     * @param ServerRequestInterface $psr7Request
+     *
      * @return ResponseInterface
      */
     public function handle(ServerRequestInterface $psr7Request): ResponseInterface
@@ -81,10 +83,8 @@ class NextHandlerAdapter implements RequestHandlerInterface
      *
      * @return ResponseInterface
      */
-    protected function getPsr7Response($response)
+    protected function getPsr7Response($response): ResponseInterface
     {
         return $this->psrHttpFactory->createResponse($response);
     }
 }
-
-;

--- a/src/NextHandlerFactory.php
+++ b/src/NextHandlerFactory.php
@@ -2,6 +2,7 @@
 
 namespace Softonic\Laravel\Middleware\Psr15Bridge;
 
+use Closure;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 use Symfony\Component\HttpFoundation\Request;
@@ -12,8 +13,8 @@ class NextHandlerFactory
         HttpFoundationFactory $httpFoundationFactory,
         PsrHttpFactory $psrHttpFactory,
         Request $request,
-        \Closure $next
-    ) {
+        Closure $next
+    ): NextHandlerAdapter {
         return new NextHandlerAdapter(
             $httpFoundationFactory,
             $psrHttpFactory,

--- a/src/Psr15MiddlewareAdapter.php
+++ b/src/Psr15MiddlewareAdapter.php
@@ -53,7 +53,7 @@ class Psr15MiddlewareAdapter
      *
      * @return Psr15MiddlewareAdapter
      */
-    public static function adapt(MiddlewareInterface $psr15Middleware)
+    public static function adapt(MiddlewareInterface $psr15Middleware): Psr15MiddlewareAdapter
     {
         $psr17Factory = new Psr17Factory();
 
@@ -71,17 +71,17 @@ class Psr15MiddlewareAdapter
      * Transform current FoundationRequest to PSR-7 to allow the PSR-15 to process it and wait for their response
      * that will be adapted from PSR-7 to HttpFoundation to allow previous middleware to process it.
      *
-     * @param Request  $foundationRequest
-     * @param \Closure $next
+     * @param Request $foundationRequest
+     * @param Closure $next
      *
      * @return Response
      */
     public function handle(Request $foundationRequest, Closure $next): Response
     {
         $psr7Request = $this->getPsr7Request($foundationRequest);
-        $next        = $this->getNextExecutionHandlerAdapter($foundationRequest, $next);
+        $nextAdapted = $this->getNextExecutionHandlerAdapter($foundationRequest, $next);
 
-        $response = $this->psr15Middleware->process($psr7Request, $next);
+        $response = $this->psr15Middleware->process($psr7Request, $nextAdapted);
 
         return $this->getResponse($response);
     }
@@ -97,7 +97,7 @@ class Psr15MiddlewareAdapter
      *
      * @return NextHandlerAdapter
      */
-    public function getNextExecutionHandlerAdapter(Request $request, Closure $next)
+    private function getNextExecutionHandlerAdapter(Request $request, Closure $next): NextHandlerAdapter
     {
         return $this->nextHandlerFactory->getHandler(
             $this->httpFoundationFactory,
@@ -114,7 +114,7 @@ class Psr15MiddlewareAdapter
      *
      * @return ServerRequestInterface
      */
-    protected function getPsr7Request(Request $request)
+    protected function getPsr7Request(Request $request): ServerRequestInterface
     {
         return $this->psrHttpFactory->createRequest($request);
     }
@@ -128,7 +128,7 @@ class Psr15MiddlewareAdapter
      */
     protected function getResponse(ResponseInterface $psr7Response): Response
     {
-        $response = new \Illuminate\Http\Response();
+        $response = new Response();
         $foundationResponse = $this->httpFoundationFactory->createResponse($psr7Response);
 
         foreach ($foundationResponse->headers as $key => $value) {

--- a/tests/NextHandlerAdapterTest.php
+++ b/tests/NextHandlerAdapterTest.php
@@ -7,27 +7,29 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class NextHandlerAdapterTest extends TestCase
 {
     /**
      * @test
      */
-    public function whenHandledItShouldAdaptTheRequestForNextMiddlewareAndResponseForThePrevious()
+    public function whenHandledItShouldAdaptTheRequestForNextMiddlewareAndResponseForThePrevious(): void
     {
         $psr7Request = $this->createMock(ServerRequestInterface::class);
         $psr7Response = $this->createMock(ResponseInterface::class);
-        $request = new \Symfony\Component\HttpFoundation\Request();
-        $response = new \Symfony\Component\HttpFoundation\Response();
+        $request = new Request();
+        $response = new Response();
 
         $httpFoundationFactory = $this->createMock(HttpFoundationFactory::class);
         $httpFoundationFactory->expects($this->once())
             ->method('createRequest')
             ->with($psr7Request)
-            ->willReturn(new \Symfony\Component\HttpFoundation\Request());
+            ->willReturn(new Request());
 
-        $diactorosFactory = $this->createMock(PsrHttpFactory::class);
-        $diactorosFactory->expects($this->once())
+        $psrFactory = $this->createMock(PsrHttpFactory::class);
+        $psrFactory->expects($this->once())
             ->method('createResponse')
             ->with($response)
             ->willReturn($psr7Response);
@@ -39,7 +41,7 @@ class NextHandlerAdapterTest extends TestCase
 
         $next = new NextHandlerAdapter(
             $httpFoundationFactory,
-            $diactorosFactory,
+            $psrFactory,
             $request,
             $next
         );

--- a/tests/Psr15MiddlewareAdapterTest.php
+++ b/tests/Psr15MiddlewareAdapterTest.php
@@ -3,7 +3,6 @@
 namespace Softonic\Laravel\Middleware\Psr15Bridge;
 
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -17,7 +16,7 @@ class Psr15MiddlewareAdapterTest extends TestCase
     /**
      * @test
      */
-    public function whenHandledItShouldAdaptTheRequestForNextMiddlewareAndResponseForThePrevious()
+    public function whenHandledItShouldAdaptTheRequestForNextMiddlewareAndResponseForThePrevious(): void
     {
         $psr7Request  = $this->createMock(ServerRequestInterface::class);
         $psr7Response = $this->createMock(ResponseInterface::class);
@@ -36,8 +35,8 @@ class Psr15MiddlewareAdapterTest extends TestCase
             ->with($psr7Response)
             ->willReturn($response);
 
-        $diactorosFactory = $this->createMock(PsrHttpFactory::class);
-        $diactorosFactory->expects($this->once())
+        $psrFactory = $this->createMock(PsrHttpFactory::class);
+        $psrFactory->expects($this->once())
             ->method('createRequest')
             ->with($request)
             ->willReturn($psr7Request);
@@ -57,7 +56,7 @@ class Psr15MiddlewareAdapterTest extends TestCase
 
         $psr15MiddlewareAdapter = new Psr15MiddlewareAdapter(
             $nextHandlerFactory,
-            $diactorosFactory,
+            $psrFactory,
             $httpFoundationFactory,
             $psr15Middleware
         );
@@ -67,7 +66,5 @@ class Psr15MiddlewareAdapterTest extends TestCase
                 'Never will be executed because the nextHandlerAdapter is mocked'
             );
         });
-
-        $this->assertInstanceOf(Response::class, $resultResponse);
     }
 }


### PR DESCRIPTION
- Put all classes in use statements
- Added type hinting in returns
- Removed missing references to diactoros in variable names.